### PR TITLE
Migrate SML lookup from CNAME to NAPTR

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -4,3 +4,4 @@ xmlsec
 asn1crypto
 certvalidator
 saxonche
+dnspython==2.*

--- a/smp.py
+++ b/smp.py
@@ -1,14 +1,19 @@
+import re
+
 from lxml import etree
 
+import base64
+import dns.resolver
 import urllib.parse
 import requests
 import hashlib
 
 from exception import make_sendpeppol_error
 
-def get_service_urls_for_participant_from_smp(participant_id, test_environment, timeout):
-    # SML: receiver -> SMP domain (DNS)
-    smp_id = 'B-' + hashlib.md5((participant_id.lower()).encode('utf-8')).hexdigest()
+
+def get_smp_url_from_dns(participant_id, test_environment):
+    smp_id = base64.b32encode(hashlib.sha256(participant_id.lower().encode()).digest()).decode().rstrip("=")
+
     if test_environment:
         base_hostname = 'acc.edelivery.tech.ec.europa.eu'
     else:
@@ -16,9 +21,38 @@ def get_service_urls_for_participant_from_smp(participant_id, test_environment, 
 
     smp_domain = f'{smp_id}.iso6523-actorid-upis.{base_hostname}'
 
+    resolver = dns.resolver.Resolver()
+    try:
+        answers = resolver.resolve(smp_domain, 'NAPTR')
+    except (dns.resolver.NXDOMAIN, dns.resolver.NoAnswer) as e:
+        raise make_sendpeppol_error(str(e), 'dns-error', temporary=False)
+    except dns.resolver.DNSException as e:
+        raise make_sendpeppol_error(str(e), 'dns-error', temporary=True)
+
+    result = None
+    for rdata in sorted(answers, key=lambda rdata: rdata.order):
+        # This is not a full implementation of the NAPTR spec (RFC2915) but should support everything used by Peppol
+        # and be somewhat safe against unexpected record contents.
+        if rdata.flags.decode().lower() == "u" and rdata.service.decode().lower() == "meta:smp":
+            delim_char = rdata.regexp.decode()[0]
+            regex_data = rdata.regexp.decode().split(delim_char)
+            result = re.sub('^' + regex_data[1] + '$', regex_data[2], smp_domain)
+
+            if not result.startswith("https://") and not result.startswith("http://"):
+                raise make_sendpeppol_error("Regexp result of NATPR record is not an URL", 'dns-error', temporary=False)
+            break
+
+    if not result:
+        raise make_sendpeppol_error("The NATPR record could not be resolved to an URL", 'dns-error', temporary=False)
+
     # SMP: domain + path -> xml with service descriptions
     # get all available interfaces (invoice, credit note etc.)
-    smp_url = 'http://' + smp_domain + "/iso6523-actorid-upis::" + participant_id
+    return result + "/iso6523-actorid-upis::" + participant_id
+
+
+def get_service_urls_for_participant_from_smp(participant_id, test_environment, timeout):
+    # SML: receiver -> SMP domain (DNS)
+    smp_url = get_smp_url_from_dns(participant_id, test_environment)
 
     try:
         r = requests.get(smp_url, timeout=timeout)


### PR DESCRIPTION
https://docs.peppol.eu/edelivery/changelog/2025-04/Peppol%20CNAME%20to%20NAPTR%20Migration%20Process%20v1.0.0%202025-04-17.pdf