### PR TITLE
Compatibility with other organization ID schemes

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -1,0 +1,31 @@
+name: Tests
+
+on:
+  push:
+    branches: [ master ]
+  pull_request:
+    branches: [ master ]
+
+jobs:
+  packaging:
+    name: tests
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - name: Set up Python 3.13
+        uses: actions/setup-python@v1
+        with:
+          python-version: 3.13
+      - uses: actions/cache@v4
+        with:
+          path: ~/.cache/pip
+          key: ${{ runner.os }}-pip-${{ hashFiles('**/setup.py') }}
+          restore-keys: |
+            ${{ runner.os }}-pip-
+      - name: Install Dependencies
+        run: pip3 install -U setuptools
+      - name: Install package and dependencies
+        run: pip3 install -e .[dev]
+      - name: Run tests
+        run: pytest
+        working-directory: src

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,1 +1,2 @@
 recursive-include src/peppol_py/data *
+recursive-exclude src/tests *

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -26,6 +26,12 @@ dependencies = [
     "dnspython==2.*", # tested with 2.8.0
 ]
 
+
+[project.optional-dependencies]
+dev = [
+    "pytest"
+]
+
 [project.urls]
 Homepage = "https://github.com/iterasdev/peppol-py"
 Issues = "https://github.com/iterasdev/peppol-py/issues"

--- a/src/tests/test_statistics.py
+++ b/src/tests/test_statistics.py
@@ -1,0 +1,30 @@
+import pytest
+
+from peppol_py.statistics import clean_organization_id
+
+
+@pytest.mark.parametrize(
+    "organization_id,organization_id_type,country_code,expected_scheme,expected_id", [
+        ("PDK000592", "DK:P", "DK", "0096", "PDK000592"),
+        ("PDK000592", "0096", "DK", "0096", "PDK000592"),
+        ("PDK000592", "DK:P", "GL", "0096", "PDK000592"),
+        ("PDK000592", "DK:P", "FO", "0096", "PDK000592"),
+        ("DK33955871", "DK:CVR", "DK", "0184", "DK33955871"),
+        ("DK33955871", "DK:CVR", "GL", "0184", "DK33955871"),
+        ("DK33955871", "DK:CVR", "FO", "0184", "DK33955871"),
+        ("919370440", "NO:ORGNR", "NO", "0192", "919370440"),
+        ("919370440", "0192", "NO", "0192", "919370440"),
+        ("1234567890", "IS:KT", "IS", "0196", "1234567890"),
+        ("2120000787", "SE:ORGNR", "SE", "0007", "2120000787"),
+        ("1548079098355", "GLN", "US", "0088", "1548079098355"),
+        ("1548079098355", "EAN", "US", "0088", "1548079098355"),
+        ("CHE012345678", "CH:UIDB", "CH", "0183", "CHE012345678"),
+        ("DE123456789", "DE:VAT", "DE", "9930", "DE123456789"),
+        ("DE123456789", "9930", "DE", "9930", "DE123456789"),
+    ]
+)
+def test_orgid_generation(organization_id, organization_id_type, country_code, expected_id, expected_scheme):
+    # country_code currently not even required
+    scheme_id, org_id = clean_organization_id(organization_id, organization_id_type)
+    assert scheme_id == expected_scheme
+    assert org_id == expected_id


### PR DESCRIPTION
``generate_organization_id`` was not ready to handle non-Nordic IDs. Also, it contained some code that shuffled a country code in front of the ID and then removed it again.

For a German Peppol ID like 9930:DE123456789, this did the wrong thing, as it converted it to 9930:123456789. I could have added DE:VAT to `PEPPOL_ORGANIZATION_ID_TYPES_WITH_COUNTRY_PREFIX`, but I could not figure out why all that complex logic is needed and did not want to figure out the full set of `PEPPOL_ORGANIZATION_ID_TYPES_WITH_COUNTRY_PREFIX` necessary.

So I wrote some unit tests to figure out what all that logic was doing and as far as I can tell… it did nothing and could just be deleted. @arj03 Please verify I'm not breaking your usage here by looking at the examples in the test cases.