### PR TITLE
Deduce service provider ID from certificate

### DIFF
--- a/README.md
+++ b/README.md
@@ -106,7 +106,7 @@ To send a prepared xml document, call `send_peppol_document`:
 from peppol_py import send_peppol_document
 stats = send_peppol_document(
     document_content, xmlsec_path, keyfile, keyfile_password, certfile,
-    service_provider_id, sender_id=None, receiver_id=None, sender_country=None,
+    sender_id=None, receiver_id=None, sender_country=None,
     document_type_version=None, test_environment=True, timeout=20, dryrun=False
 )
 ```

--- a/src/peppol_py/__main__.py
+++ b/src/peppol_py/__main__.py
@@ -27,7 +27,6 @@ def main():
 
     parser_send = subparsers.add_parser('send', help='Send a Peppol document')
     parser_send.add_argument('--document', help="The path of the document to send", required=True)
-    parser_send.add_argument('--service-provider', help="Service provider ID", required=True)
     parser_send.add_argument('--xmlsec-path', default='xmlsec1', help="The path to latest xmlsec binary")
     parser_send.add_argument('--schematron-path', default=['PEPPOL-EN16931-UBL.xsl'],
                              nargs='+', help="Schematron XSL files to validate with, defaults to bundled PEPPOL-EN16931-UBL.xsl")
@@ -65,8 +64,7 @@ def main():
             stats = send_peppol_document(document_content,
                                          parsed_args.xmlsec_path, parsed_args.keyfile,
                                          keyfile_password=parsed_args.password, certfile=parsed_args.certfile,
-                                         test_environment=parsed_args.test, document_type_version='2.1',
-                                         service_provider_id=parsed_args.service_provider)
+                                         test_environment=parsed_args.test, document_type_version='2.1')
             print(stats)
         except SendPeppolError as ex:
             print(f"Failed with: {ex.code} {ex}")

--- a/src/peppol_py/sender.py
+++ b/src/peppol_py/sender.py
@@ -113,7 +113,6 @@ def send_peppol_document(
     keyfile: str,
     keyfile_password: str,
     certfile: str,
-    service_provider_id: str,
     sender_id: str=None,
     receiver_id: str=None,
     sender_country: str=None,
@@ -187,6 +186,7 @@ def send_peppol_document(
 
     with open(certfile, 'rb') as sender_certfile_f:
         sender_cert = sender_certfile_f.read()
+    service_provider_id = get_common_name_from_certificate(sender_cert)
 
     validate_certificate(receiver_cert, test_environment)
     to_party_id = get_common_name_from_certificate(receiver_cert)

--- a/src/peppol_py/statistics.py
+++ b/src/peppol_py/statistics.py
@@ -280,7 +280,7 @@ def send_peppol_statistics(
         try:
             results.append(
                 send_peppol_document(
-                    xml, xmlsec_path, keyfile, password, certfile, sender_id=sender_id, receiver_id=receiver_id, sender_country=our_endpoint['country'], test_environment=test_environment, timeout=20, service_provider_id=sender_common_name,
+                    xml, xmlsec_path, keyfile, password, certfile, sender_id=sender_id, receiver_id=receiver_id, sender_country=our_endpoint['country'], test_environment=test_environment, timeout=20,
                 )
             )
         except SendPeppolError as ex:


### PR DESCRIPTION
Currently, send_peppol_statistics does not work. This fixes it.

@arj03 Do you think we should deduce it from the certificate in send_peppol_document as well and remove the function argument that I introduced again? Or add it to a parameter to both? It's a little inconsistent now.