### PR TITLE
Strip newlines from certificate

### DIFF
--- a/src/peppol_py/smp.py
+++ b/src/peppol_py/smp.py
@@ -122,7 +122,7 @@ def get_service_info_for_participant_from_smp(participant_id, document_type, tes
         endpoint_url = endpoint_e.findtext('./{*}EndpointReference/{*}Address')
         certificate = endpoint_e.findtext('./{*}Certificate')
         if certificate:
-            certificate = b'-----BEGIN CERTIFICATE-----\n' + certificate.encode('ascii') + b'\n-----END CERTIFICATE-----'
+            certificate = b'-----BEGIN CERTIFICATE-----\n' + certificate.strip().encode('ascii') + b'\n-----END CERTIFICATE-----'
 
         break
 


### PR DESCRIPTION
Fixes real-world problem observed with https://peppol-smp.odoo.com/

SMP returns XML with newline after certificate:

```
wTVTaqw7G17CmbbpORXZb+aJyCJrvKQAg68/dIrJa5IFkqo8Vdh8B4v4MhtbLqeytu5ThfCyU4/o
AE864Gu/7azxF0bNxqWfXNDxoilHSwH4q8EQQOI=
</smp:Certificate>
```

This causes us to write:

```
wTVTaqw7G17CmbbpORXZb+aJyCJrvKQAg68/dIrJa5IFkqo8Vdh8B4v4MhtbLqeytu5ThfCyU4/o
AE864Gu/7azxF0bNxqWfXNDxoilHSwH4q8EQQOI=

-----END CERTIFICATE-----
```

Which trips xmlsec:

```
SendPeppolError: xmlsec: Error: xmlSecCryptoAppKeyLoadEx failed: file=/tmp/temp-sendpeppol-certfile-d3cb5lzt.pem
Error: failed to load public key from "/tmp/temp-sendpeppol-certfile-d3cb5lzt.pem".
Error: keys manager creation failed
Unknown command
```